### PR TITLE
實作由房主觸發的同步開始投票功能

### DIFF
--- a/src/firebase/rooms.js
+++ b/src/firebase/rooms.js
@@ -398,4 +398,34 @@ export const getRecommendationResults = async (roomId) => {
     console.error('獲取推薦結果失敗:', error)
     throw error
   }
+}
+
+/**
+ * 更新房間投票狀態
+ * @param {string} roomId - 房間ID
+ * @param {string} status - 狀態 ('waiting', 'active', 'completed')
+ * @returns {Promise<boolean>} 更新結果
+ */
+export const updateRoomVotingStatus = async (roomId, status) => {
+  try {
+    if (!roomId) {
+      throw new Error('未提供房間ID')
+    }
+    
+    if (!['waiting', 'active', 'completed'].includes(status)) {
+      throw new Error('無效的投票狀態')
+    }
+    
+    const roomRef = doc(db, 'rooms', roomId)
+    await updateDoc(roomRef, {
+      votingStatus: status,
+      votingUpdatedAt: serverTimestamp()
+    })
+    
+    console.log(`已更新房間 ${roomId} 投票狀態為: ${status}`)
+    return true
+  } catch (error) {
+    console.error('更新投票狀態失敗:', error)
+    throw error
+  }
 } 

--- a/src/views/WaitingRoom.vue
+++ b/src/views/WaitingRoom.vue
@@ -2,31 +2,37 @@
 import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useNicknameStorage } from '@/composables/storage/useNicknameStorage'
-import { leaveRoom, getRoomById, watchRoom } from '@/firebase/rooms'
+import { leaveRoom, getRoomById, watchRoom, updateRoomVotingStatus } from '@/firebase/rooms'
 import NavigationBack from '@/components/common/NavigationBack.vue'
 import { useToast } from '@/composables/useToast'
 
+// 基本狀態管理
 const route = useRoute()
 const router = useRouter()
 const nicknameStorage = useNicknameStorage()
 const toast = useToast()
 
+// 房間狀態
 const roomId = ref('')
 const roomCode = ref('')
-const isLoading = ref(false)
-const isOwner = ref(false)
-const unsubscribe = ref(null)
+const roomOwnerId = ref('')
 const participants = ref({})
 const maxParticipants = ref(8)
-const roomOwnerId = ref('')
+
+// 用戶狀態
 const currentUserId = ref('')
+const isOwner = ref(false)
+const isLoading = ref(false)
+const isNavigating = ref(false)
 
-// 計算已加入成員數
-const participantsCount = computed(() => {
-  return Object.keys(participants.value).length
-})
+// 清理函數
+const unsubscribe = ref(null)
 
-// 生成隨機顏色
+// 計算屬性
+const participantsCount = computed(() => Object.keys(participants.value).length)
+
+// ===== 參與者UI處理 =====
+// 顏色管理
 const backgroundColors = {
   0: 'bg-indigo-500',
   1: 'bg-pink-500',
@@ -37,9 +43,13 @@ const backgroundColors = {
   6: 'bg-blue-500',
   7: 'bg-teal-500',
 }
-
 const colorMap = ref({})
 
+/**
+ * 為用戶分配一個唯一顏色
+ * @param {string} userId - 用戶ID
+ * @returns {string} 顏色類名
+ */
 const getColorForUser = (userId) => {
   if (!colorMap.value[userId]) {
     const usedColors = Object.values(colorMap.value)
@@ -60,78 +70,92 @@ const getColorForUser = (userId) => {
   return colorMap.value[userId];
 }
 
-// 獲取顯示的首字
+/**
+ * 獲取用戶暱稱的首字母
+ * @param {string} nickname - 用戶暱稱
+ * @returns {string} 首字母
+ */
 const getFirstLetter = (nickname) => {
   return nickname ? nickname.charAt(0).toUpperCase() : '?'
 }
 
-// 檢查是否為房主
+/**
+ * 檢查參與者是否為房主
+ * @param {Object} participantData - 參與者數據
+ * @returns {boolean} 是否為房主
+ */
 const checkIsOwner = (participantData) => {
   return participantData.isOwner
 }
 
-onMounted(async () => {
-  const urlRoomId = route.query.roomId
-  if (urlRoomId) {
-    roomId.value = urlRoomId
-    currentUserId.value = nicknameStorage.nickname.value
+// ===== 房間操作 =====
+/**
+ * 更新房間參與者狀態
+ * @param {Object} roomData - 房間數據
+ */
+const updateRoomState = (roomData) => {
+  if (!roomData) {
+    handleRoomDeleted()
+    return
+  }
 
-    try {
-      const room = await getRoomById(urlRoomId)
-      if (room) {
-        roomCode.value = room.roomCode
-        roomOwnerId.value = room.ownerId
-        isOwner.value = room.ownerId === currentUserId.value
-        participants.value = room.participants || {}
+  // 更新房間基本信息
+  roomCode.value = roomData.roomCode
+  roomOwnerId.value = roomData.ownerId
+  isOwner.value = roomData.ownerId === currentUserId.value
 
-        // 為所有參與者分配顏色
-        Object.keys(participants.value).forEach(participantId => {
-          getColorForUser(participantId)
-        })
+  // 更新參與者
+  updateParticipants(roomData.participants || {})
 
-        // 監聽房間狀態
-        unsubscribe.value = watchRoom(urlRoomId, (room) => {
-          if (!room) {
-            // 房間被刪除
-            toast.success('房主已離開房間')
-            // 延遲跳轉，讓使用者看到提示訊息
-            setTimeout(() => {
-              router.push('/')
-            }, 1500)
-            return
-          }
+  // 檢查投票狀態
+  if (roomData.votingStatus === 'active') {
+    handleVotingStarted()
+  }
+}
 
-          // 更新房間資訊
-          roomCode.value = room.roomCode
-          roomOwnerId.value = room.ownerId
-          isOwner.value = room.ownerId === currentUserId.value
+/**
+ * 更新參與者列表並分配顏色
+ * @param {Object} newParticipants - 新參與者列表
+ */
+const updateParticipants = (newParticipants) => {
+  const prevParticipants = { ...participants.value }
+  participants.value = newParticipants
 
-          // 更新參與者列表
-          const prevParticipants = { ...participants.value }
-          participants.value = room.participants || {}
+  // 為新參與者分配顏色
+  Object.keys(newParticipants).forEach(participantId => {
+    if (!prevParticipants[participantId]) {
+      getColorForUser(participantId)
+    }
+  })
+}
 
-          // 為新參與者分配顏色
-          Object.keys(participants.value).forEach(participantId => {
-            if (!prevParticipants[participantId]) {
-              getColorForUser(participantId)
-            }
-          })
-        })
-      }
-    } catch (err) {
-      console.error('獲取房間資訊失敗:', err)
-      toast.error('獲取房間資訊失敗')
-      router.push('/')
+/**
+ * 處理房間被刪除的情況
+ */
+const handleRoomDeleted = () => {
+  toast.success('房主已離開房間')
+  // 延遲跳轉，讓使用者看到提示訊息
+  setTimeout(() => {
+    router.push('/')
+  }, 1500)
+}
+
+/**
+ * 獲取當前用戶的參與者ID
+ * @returns {string|null} 參與者ID
+ */
+const getCurrentParticipantId = () => {
+  for (const [pid, participant] of Object.entries(participants.value)) {
+    if (participant.userId === currentUserId.value) {
+      return pid
     }
   }
-})
+  return null
+}
 
-onUnmounted(() => {
-  if (unsubscribe.value) {
-    unsubscribe.value()
-  }
-})
-
+/**
+ * 處理用戶離開房間
+ */
 const handleLeaveRoom = async () => {
   if (!roomId.value || !currentUserId.value) {
     toast.error('系統錯誤')
@@ -151,34 +175,9 @@ const handleLeaveRoom = async () => {
   }
 }
 
-const startVoting = () => {
-  console.log('開始投票')
-  // 保存到localStorage以便在頁面刷新時恢復
-  localStorage.setItem('currentRoomId', roomId.value);
-
-  // 找到當前用戶的 participantId
-  let currentParticipantId = null;
-
-  // 查找當前用戶在參與者列表中的 ID
-  for (const [pid, participant] of Object.entries(participants.value)) {
-    if (participant.userId === currentUserId.value) {
-      currentParticipantId = pid;
-      break;
-    }
-  }
-
-  if (!currentParticipantId) {
-    toast.error('無法找到您的參與者資訊');
-    return;
-  }
-
-  localStorage.setItem('currentParticipantId', currentParticipantId);
-
-  // 跳轉到投票頁面，帶上參數
-  router.push(`/voting-form?roomId=${roomId.value}&participantId=${currentParticipantId}`);
-};
-
-// 複製房間代碼
+/**
+ * 複製房間代碼到剪貼板
+ */
 const copyRoomCode = async () => {
   if (!roomCode.value) return
 
@@ -190,6 +189,102 @@ const copyRoomCode = async () => {
     toast.error('複製失敗')
   }
 }
+
+// ===== 投票相關功能 =====
+/**
+ * 開始投票流程
+ */
+const startVoting = async () => {
+  if (isLoading.value || isNavigating.value) return
+
+  try {
+    isLoading.value = true
+    const currentParticipantId = getCurrentParticipantId()
+
+    if (!currentParticipantId) {
+      toast.error('無法找到您的參與者資訊')
+      isLoading.value = false
+      return
+    }
+
+    // 儲存到localStorage
+    localStorage.setItem('currentRoomId', roomId.value)
+    localStorage.setItem('currentParticipantId', currentParticipantId)
+
+    // 如果是房主，更新房間狀態
+    if (isOwner.value) {
+      await updateRoomVotingStatus(roomId.value, 'active')
+      toast.success('已通知所有成員進入投票')
+    }
+
+    // 導航到投票頁面
+    isNavigating.value = true
+    router.push(`/voting-form?roomId=${roomId.value}&participantId=${currentParticipantId}`)
+  } catch (err) {
+    console.error('開始投票失敗:', err)
+    toast.error('開始投票失敗，請稍後再試')
+    isLoading.value = false
+    isNavigating.value = false
+  }
+}
+
+/**
+ * 處理投票已開始的情況
+ */
+const handleVotingStarted = () => {
+  if (isNavigating.value) return
+
+  const currentParticipantId = getCurrentParticipantId()
+  if (!currentParticipantId) return
+
+  isNavigating.value = true
+
+  // 儲存參數
+  localStorage.setItem('currentRoomId', roomId.value)
+  localStorage.setItem('currentParticipantId', currentParticipantId)
+
+  // 顯示提示並跳轉
+  toast.info('投票已開始，正在跳轉...')
+  setTimeout(() => {
+    router.push(`/voting-form?roomId=${roomId.value}&participantId=${currentParticipantId}`)
+  }, 1000)
+}
+
+// ===== 生命週期鉤子 =====
+onMounted(async () => {
+  const urlRoomId = route.query.roomId
+  if (!urlRoomId) {
+    router.push('/')
+    return
+  }
+
+  roomId.value = urlRoomId
+  currentUserId.value = nicknameStorage.nickname.value
+
+  try {
+    // 初始獲取房間數據
+    const room = await getRoomById(urlRoomId)
+    if (room) {
+      updateRoomState(room)
+
+      // 設置房間監聽
+      unsubscribe.value = watchRoom(urlRoomId, updateRoomState)
+    } else {
+      toast.error('找不到房間')
+      router.push('/')
+    }
+  } catch (err) {
+    console.error('獲取房間資訊失敗:', err)
+    toast.error('獲取房間資訊失敗')
+    router.push('/')
+  }
+})
+
+onUnmounted(() => {
+  if (unsubscribe.value) {
+    unsubscribe.value()
+  }
+})
 </script>
 
 <template>
@@ -197,6 +292,7 @@ const copyRoomCode = async () => {
     <div class="w-full max-w-md">
       <NavigationBack text="離開房間" :is-custom-action="true" @custom-action="handleLeaveRoom" />
       <div class="w-full bg-white rounded-lg p-8 shadow-lg">
+        <!-- 房間標題和資訊 -->
         <div class="flex items-center justify-between">
           <h1 class="text-2xl font-bold">等待其他玩家加入</h1>
           <div class="flex items-center gap-2">
@@ -206,9 +302,13 @@ const copyRoomCode = async () => {
             </span>
           </div>
         </div>
+
+        <!-- 參與者計數 -->
         <div class="mt-4">
           <span class="text-sm text-gray-800">已加入成員({{ participantsCount }}/{{ maxParticipants }})</span>
         </div>
+
+        <!-- 參與者列表 -->
         <div class="grid grid-cols-4 gap-3 mt-4">
           <div v-for="(participant, participantId) in participants" :key="participantId" class="text-center member-item">
             <div :class="[getColorForUser(participantId), 'w-14 h-14 rounded-full flex items-center justify-center text-white text-lg font-bold mx-auto mb-1 joined-animation']">
@@ -220,7 +320,12 @@ const copyRoomCode = async () => {
             </div>
           </div>
         </div>
-        <button class="w-full bg-red-gradient text-white px-4 py-2 rounded-lg mt-8 cursor-pointer" @click="startVoting">開始投票</button>
+
+        <!-- 操作按鈕 -->
+        <button class="w-full bg-red-gradient text-white px-4 py-2 rounded-lg mt-8 cursor-pointer disabled:opacity-70" @click="startVoting" :disabled="isLoading">
+          <span v-if="isLoading">處理中...</span>
+          <span v-else>開始投票</span>
+        </button>
       </div>
     </div>
   </div>
@@ -249,5 +354,9 @@ const copyRoomCode = async () => {
 
 .member-item {
   transition: all 0.3s ease;
+}
+
+.bg-red-gradient {
+  background: linear-gradient(to right, #f43f5e, #ef4444);
 }
 </style>


### PR DESCRIPTION
# 功能：房主可觸發所有參與者進入投票頁面

## 功能描述
實現房主可以一鍵開始投票的功能，當房主點擊「開始投票」按鈕後，所有房間內的參與者將同步收到通知並自動導向至投票頁面。

## 實現方式
- 在等待室介面中新增房主專屬的「開始投票」按鈕
- 使用 Firebase Firestore 的即時更新機制同步投票狀態
- 將複雜邏輯模組化，遵循關注點分離原則，提高程式碼可維護性
- 優化使用者體驗，提供操作反饋與載入狀態

## 技術細節
- 使用 `onSnapshot` 監聽房間投票狀態變更
- 實現 `updateRoomVotingStatus` 函數更新房間投票狀態
- 重構 `WaitingRoom.vue` 提高程式碼可讀性與可維護性
- 使用 Vue 3 Composition API 與 `<script setup>` 格式
