### PR TITLE
將用戶下拉選單從 App.vue 移至 Home.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,6 @@
 <script setup>
 import ToastContainer from '@/components/common/ToastContainer.vue'
 import ModalContainer from '@/components/common/ModalContainer.vue'
-import UserDropdown from '@/components/profile/UserDropdown.vue'
 import { useAuth } from '@/composables/auth/useAuth'
 import { useToast } from '@/composables/useToast'
 import { useNicknameStorage } from '@/composables/storage/useNicknameStorage'
@@ -39,11 +38,6 @@ const handleLogout = async () => {
 
 <template>
   <div class="app-container">
-    <!-- 全局用戶下拉菜單 -->
-    <div v-if="user" class="global-user-dropdown">
-      <UserDropdown :user="user" @logout="handleLogout" />
-    </div>
-
     <main class="router-view-container">
       <router-view v-slot="{ Component }">
         <transition name="page" mode="out-in" appear>
@@ -76,14 +70,6 @@ const handleLogout = async () => {
 .page-leave-to {
   opacity: 0;
   transform: translateX(-20px);
-}
-
-/* 全局用戶下拉菜單樣式 */
-.global-user-dropdown {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  z-index: 100;
 }
 
 /* 確保應用程序容器有適當的間距 */

--- a/src/components/common/ModalContainer.vue
+++ b/src/components/common/ModalContainer.vue
@@ -8,7 +8,7 @@ const modalStore = useModalStore()
 
 <template>
   <Transition name="modal-backdrop">
-    <div class="fixed inset-0 flex items-center justify-center bg-black/60 z-50" v-if="modalStore.modal">
+    <div class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 p-4 sm:p-2" v-if="modalStore.modal">
       <Transition name="modal-content">
         <Modal :type="modalStore.modal.type" :title="modalStore.modal.title" :message="modalStore.modal.message" />
       </Transition>

--- a/src/components/profile/UserDropdown.vue
+++ b/src/components/profile/UserDropdown.vue
@@ -97,7 +97,7 @@ onUnmounted(() => {
     <!-- 用戶頭像按鈕 -->
     <button @click.stop="toggleDropdown" class="flex items-center space-x-2 focus:outline-none transition-all duration-200 rounded-full p-1">
       <!-- 如果有頭像則顯示頭像，否則顯示首字母頭像 -->
-      <div v-if="user.photoURL" class="w-8 h-8 rounded-full overflow-hidden border-2 border-white shadow-sm">
+      <div v-if="user?.photoURL" class="w-8 h-8 rounded-full overflow-hidden border-2 border-white shadow-sm">
         <img :src="user.photoURL" alt="用戶頭像" class="w-full h-full object-cover" />
       </div>
       <div v-else :class="[avatarBgColor, 'w-8 h-8 rounded-full flex items-center justify-center text-white font-medium shadow-sm border-2 border-white']">
@@ -115,7 +115,7 @@ onUnmounted(() => {
       <!-- 用戶資訊區塊 -->
       <div class="p-4 border-b border-gray-100">
         <p class="font-medium text-gray-800">{{ displayName }}</p>
-        <p class="text-xs text-gray-500 truncate">{{ user.email }}</p>
+        <p class="text-xs text-gray-500 truncate">{{ user?.email }}</p>
       </div>
 
       <!-- 選單項目 -->

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,6 +2,7 @@
 import { useNicknameStorage } from '@/composables/storage/useNicknameStorage'
 import NicknameEditor from '@/components/profile/NicknameEditor.vue'
 import LogoHeader from '@/components/common/LogoHeader.vue'
+import UserDropdown from '@/components/profile/UserDropdown.vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useToast } from '@/composables/useToast'
 import { onMounted, ref, computed } from 'vue'
@@ -12,7 +13,7 @@ const nicknameStorage = useNicknameStorage()
 const router = useRouter()
 const route = useRoute()
 const toast = useToast()
-const { user } = useAuth()
+const { user, logout, initialize } = useAuth()
 const shouldRedirect = ref(false)
 const redirectPath = ref('')
 
@@ -32,8 +33,24 @@ const useDisplayNameAsNickname = () => {
   }
 }
 
+// 處理登出
+const handleLogout = async () => {
+  try {
+    await logout()
+    toast.success('登出成功')
+    // 清除暱稱資料
+    nicknameStorage.clearNickname()
+    // 重定向至登入頁
+    router.push('/login')
+  } catch (error) {
+    toast.error('登出失敗：' + error.message)
+  }
+}
+
 // 檢查URL參數
 onMounted(() => {
+  initialize()
+  
   // 檢查是否有提示設置暱稱的標記
   const requireNickname = route.query.requireNickname === 'true'
   const roomCode = route.query.roomCode
@@ -96,10 +113,19 @@ const navigateToCreateRoom = () => {
 const navigateToJoinRoom = () => {
   router.push('/join-room')
 }
+
+const version = computed(() => {
+  return import.meta.env.VITE_APP_VERSION
+})
 </script>
 
 <template>
   <div class="flex flex-col min-h-screen w-full">
+    <!-- 用戶下拉菜單 -->
+    <div v-if="true" class="home-user-dropdown">
+      <UserDropdown :user="user" @logout="handleLogout" />
+    </div>
+
     <!-- 主要內容 -->
     <div class="flex justify-center items-center flex-grow py-8 px-4 sm:py-12 w-full">
       <div class="w-full max-w-md">
@@ -137,7 +163,7 @@ const navigateToJoinRoom = () => {
 
         <!-- 版本資訊 -->
         <div class="mt-6 text-center">
-          <p class="text-xs text-gray-500">版本 1.0.0</p>
+          <p class="text-xs text-gray-500">版本 {{ version }}</p>
         </div>
       </div>
     </div>
@@ -145,5 +171,11 @@ const navigateToJoinRoom = () => {
 </template>
 
 <style scoped>
-/* 只保留必要的樣式 */
+/* 用戶下拉菜單樣式 */
+.home-user-dropdown {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 100;
+}
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -113,6 +113,7 @@ const navigateToCreateRoom = () => {
 const navigateToJoinRoom = () => {
   router.push('/join-room')
 }
+console.log('version',import.meta.env.VITE_APP_VERSION);
 
 const version = computed(() => {
   return import.meta.env.VITE_APP_VERSION

--- a/src/views/VotingForm.vue
+++ b/src/views/VotingForm.vue
@@ -255,7 +255,7 @@ const flavorOptions = [{
 </script>
 
 <template>
-  <div class="flex items-center flex-col">
+  <div class="flex items-center flex-col p-2">
     <div class="w-full max-w-md bg-gray-50 rounded-lg p-6 shadow-lg mt-4 mb-4">
       <div class="flex justify-between items-center gap-2">
         <h1 class="text-xl font-bold">晚餐吃什麼 ?</h1>

--- a/src/views/VotingResult.vue
+++ b/src/views/VotingResult.vue
@@ -268,7 +268,7 @@ const handleImageError = (e) => {
 </script>
 
 <template>
-  <div class="flex flex-col items-center min-h-screen pb-8">
+  <div class="flex flex-col items-center min-h-screen p-4 sm:p-2">
     <!-- 加載畫面 -->
     <div v-if="isLoading" class="w-full max-w-md mt-12 flex flex-col items-center justify-center">
       <div class="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-red-500 mb-4"></div>

--- a/src/views/WaitingRoom.vue
+++ b/src/views/WaitingRoom.vue
@@ -549,7 +549,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex items-center h-screen flex-col">
+  <div class="flex items-center h-screen flex-col p-4 sm:p-2">
     <div class="w-full max-w-md">
       <NavigationBack text="離開房間" :is-custom-action="true" @custom-action="handleLeaveRoom" />
 


### PR DESCRIPTION


# 將用戶下拉選單從 App.vue 移至 Home.vue

## 變更摘要

本 PR 將用戶下拉選單 (UserDropdown) 元件從 App.vue 移至 Home.vue，使其只在首頁顯示，而不是全局顯示在所有頁面中。

## 主要變更

- 從 App.vue 中移除 UserDropdown 元件及相關樣式
- 在 Home.vue 中添加 UserDropdown 元件
- 在 Home.vue 中實現登出功能處理
- 修正用戶對象可能為空的情況 (使用可選鏈語法)
- 在 Home.vue 中添加初始化身份驗證的邏輯

## UI 變更

UserDropdown 元件現在固定在首頁頂部右側，使用固定定位確保其不隨頁面內容滾動。這樣的設計能讓用戶在首頁輕鬆訪問個人資料操作，但不會在其他功能頁面干擾用戶體驗。

## 修復問題

- 修復了當 user 對象為 null 時存取 photoURL 和 email 屬性可能導致的錯誤

## 其他改進

- 更新了顯示版本號的邏輯，使用環境變數 VITE_APP_VERSION
- 改進了部分頁面的內邊距，優化移動端顯示效果
