### PR TITLE
[重構]: 將參與者識別從 UUID 切換為 Firebase UID

### DIFF
--- a/src/composables/auth/useAuth.js
+++ b/src/composables/auth/useAuth.js
@@ -1,4 +1,4 @@
-import { ref, computed } from 'vue';
+import { ref, computed, readonly, onUnmounted } from 'vue';
 import { 
   createUserWithEmailAndPassword, 
   signInWithEmailAndPassword, 
@@ -12,6 +12,7 @@ import { useToast } from '@/composables/useToast';
 export function useAuth() {
   const user = ref(null);
   const loading = ref(true);
+  const isAuthReady = ref(false);
   const error = ref(null);
   const toast = useToast();
   
@@ -32,9 +33,11 @@ export function useAuth() {
       } else {
         user.value = null;
       }
+      if (!isAuthReady.value) isAuthReady.value = true;
     }, (err) => {
       loading.value = false;
       error.value = err.message;
+      if (!isAuthReady.value) isAuthReady.value = true;
       toast.error(`驗證狀態監聽錯誤: ${err.message}`);
     });
     
@@ -156,9 +159,10 @@ export function useAuth() {
   };
   
   return {
-    user,
-    loading,
-    error,
+    user: readonly(user),
+    loading: readonly(loading),
+    error: readonly(error),
+    isAuthReady: readonly(isAuthReady),
     isAuthenticated,
     initialize,
     register,

--- a/src/composables/auth/useAuth.js
+++ b/src/composables/auth/useAuth.js
@@ -12,7 +12,6 @@ import { useToast } from '@/composables/useToast';
 export function useAuth() {
   const user = ref(null);
   const loading = ref(true);
-  const isAuthReady = ref(false);
   const error = ref(null);
   const toast = useToast();
   
@@ -33,11 +32,10 @@ export function useAuth() {
       } else {
         user.value = null;
       }
-      if (!isAuthReady.value) isAuthReady.value = true;
     }, (err) => {
+      console.error('[useAuth] onAuthStateChanged error:', err);
       loading.value = false;
       error.value = err.message;
-      if (!isAuthReady.value) isAuthReady.value = true;
       toast.error(`驗證狀態監聽錯誤: ${err.message}`);
     });
     
@@ -162,7 +160,6 @@ export function useAuth() {
     user: readonly(user),
     loading: readonly(loading),
     error: readonly(error),
-    isAuthReady: readonly(isAuthReady),
     isAuthenticated,
     initialize,
     register,

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,5 +1,7 @@
 import { createPinia } from 'pinia'
+import { useUserStore } from './user'
 
 const pinia = createPinia()
 
-export default pinia 
+export default pinia
+export { useUserStore } 

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,0 +1,75 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { auth } from '@/firebase'
+import { signOut } from 'firebase/auth'
+import { useToast } from '@/composables/useToast'
+import { useNicknameStorage } from '@/composables/storage/useNicknameStorage'
+
+export const useUserStore = defineStore('user', () => {
+  // 狀態
+  const user = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  // 計算屬性
+  const isAuthenticated = computed(() => !!user.value)
+  const uid = computed(() => user.value?.uid)
+  const displayName = computed(() => user.value?.displayName || '')
+  const email = computed(() => user.value?.email || '')
+  const photoURL = computed(() => user.value?.photoURL || '')
+
+  // 操作方法
+  const setUser = (userData) => {
+    if (userData) {
+      user.value = {
+        uid: userData.uid,
+        email: userData.email,
+        displayName: userData.displayName || '',
+        photoURL: userData.photoURL || ''
+      }
+    } else {
+      user.value = null
+    }
+  }
+
+  const clearUser = () => {
+    user.value = null
+  }
+
+  const logout = async () => {
+    const toast = useToast()
+    const nicknameStorage = useNicknameStorage()
+
+    loading.value = true
+    error.value = null
+
+    try {
+      await signOut(auth)
+      clearUser()
+      nicknameStorage.clearNickname()
+      toast.success('登出成功')
+      return true
+    } catch (err) {
+      error.value = err.message
+      toast.error(`登出失敗：${err.message}`)
+      return false
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // 返回
+  return {
+    user,
+    loading,
+    error,
+    isAuthenticated,
+    uid,
+    displayName,
+    email,
+    photoURL,
+    setUser,
+    clearUser,
+    logout
+  }
+}) 

--- a/src/views/CreateRoom.vue
+++ b/src/views/CreateRoom.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useNicknameStorage } from '@/composables/storage/useNicknameStorage'
 import { useAuth } from '@/composables/auth/useAuth'
@@ -21,6 +21,9 @@ const locationInput = ref(null)
 const expiryTime = ref('30')
 const isAnonymous = ref(false)
 const isLoading = ref(false)
+
+// 新增計算屬性，合併 Auth 狀態和創建房間狀態
+const isProcessing = computed(() => isLoading.value || !auth.isAuthReady.value)
 
 // 地址自動完成
 const {
@@ -64,6 +67,12 @@ const handleGetCurrentLocation = async () => {
 }
 
 const handleCreateRoom = async () => {
+  // 函數開頭檢查 Auth 狀態
+  if (!auth.isAuthReady.value) {
+    toast.error('正在確認登入狀態，請稍候...')
+    return
+  }
+
   if (!nicknameStorage.hasNickname()) {
     toast.error('請先設定暱稱')
     return
@@ -179,8 +188,8 @@ const handleCreateRoom = async () => {
           <label for="isAnonymous" class="text-sm text-gray-600">匿名模式 (不顯示投票者)</label>
         </div>
         <div class="mt-6">
-          <button :disabled="isLoading || !roomName.trim() || !selectedPlace" @click="handleCreateRoom" class="w-full bg-red-gradient text-white py-3 rounded-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">
-            {{ isLoading ? '創建中...' : '創建房間' }}
+          <button :disabled="isProcessing || !roomName.trim() || !selectedPlace" @click="handleCreateRoom" class="w-full bg-red-gradient text-white py-3 rounded-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">
+            {{ isProcessing ? '處理中...' : '創建房間' }}
           </button>
         </div>
       </div>

--- a/src/views/CreateRoom.vue
+++ b/src/views/CreateRoom.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useNicknameStorage } from '@/composables/storage/useNicknameStorage'
 import { useAuth } from '@/composables/auth/useAuth'
@@ -21,9 +21,6 @@ const locationInput = ref(null)
 const expiryTime = ref('30')
 const isAnonymous = ref(false)
 const isLoading = ref(false)
-
-// 新增計算屬性，合併 Auth 狀態和創建房間狀態
-const isProcessing = computed(() => isLoading.value || !auth.isAuthReady.value)
 
 // 地址自動完成
 const {
@@ -188,8 +185,8 @@ const handleCreateRoom = async () => {
           <label for="isAnonymous" class="text-sm text-gray-600">匿名模式 (不顯示投票者)</label>
         </div>
         <div class="mt-6">
-          <button :disabled="isProcessing || !roomName.trim() || !selectedPlace" @click="handleCreateRoom" class="w-full bg-red-gradient text-white py-3 rounded-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">
-            {{ isProcessing ? '處理中...' : '創建房間' }}
+          <button :disabled="isLoading || !roomName.trim() || !selectedPlace" @click="handleCreateRoom" class="w-full bg-red-gradient text-white py-3 rounded-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">
+            {{ isLoading ? '創建中...' : '創建房間' }}
           </button>
         </div>
       </div>

--- a/src/views/CreateRoom.vue
+++ b/src/views/CreateRoom.vue
@@ -9,12 +9,14 @@ import { useToast } from '@/composables/useToast'
 import useGoogleMapsAutocomplete from '@/composables/maps/useGoogleMapsAutocomplete'
 import { useCurrentLocation } from '@/composables/maps/useCurrentLocation'
 import { useRoomStore } from '@/stores/room'
+import { useUserStore } from '@/stores'
 
 const router = useRouter()
 const nicknameStorage = useNicknameStorage()
 const toast = useToast()
 const roomStore = useRoomStore()
 const auth = useAuth()
+const userStore = useUserStore()
 
 const roomName = ref('')
 const locationInput = ref(null)
@@ -64,12 +66,6 @@ const handleGetCurrentLocation = async () => {
 }
 
 const handleCreateRoom = async () => {
-  // 函數開頭檢查 Auth 狀態
-  if (!auth.isAuthReady.value) {
-    toast.error('正在確認登入狀態，請稍候...')
-    return
-  }
-
   if (!nicknameStorage.hasNickname()) {
     toast.error('請先設定暱稱')
     return
@@ -80,7 +76,7 @@ const handleCreateRoom = async () => {
     return
   }
 
-  if (!auth.user.value) {
+  if (!userStore.user) {
     toast.error('請先登入')
     router.push('/login')
     return
@@ -92,7 +88,7 @@ const handleCreateRoom = async () => {
 
     const roomData = {
       name: roomName.value.trim(),
-      userUid: auth.user.value.uid,
+      userUid: userStore.user.uid,
       displayName: displayName
     }
 
@@ -119,7 +115,7 @@ const handleCreateRoom = async () => {
     roomStore.setRoomStore({
       roomName: roomName.value.trim(),
       roomId: room.id,
-      roomOwner: auth.user.value.uid
+      roomOwner: userStore.user.uid
     })
     router.push(`/waiting-room?roomId=${room.id}`)
   } catch (err) {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -5,22 +5,26 @@ import LogoHeader from '@/components/common/LogoHeader.vue'
 import UserDropdown from '@/components/profile/UserDropdown.vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useToast } from '@/composables/useToast'
-import { onMounted, ref, computed } from 'vue'
+import { onMounted, ref, computed, watch } from 'vue'
 import { STORAGE_KEYS } from '@/constants/storage-keys'
 import { useAuth } from '@/composables/auth/useAuth'
+import { useUserStore } from '@/stores'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '@/firebase'
 
 const nicknameStorage = useNicknameStorage()
 const router = useRouter()
 const route = useRoute()
 const toast = useToast()
-const { user, logout, initialize } = useAuth()
+const { user, loading, error, initialize } = useAuth()
+const userStore = useUserStore()
 const shouldRedirect = ref(false)
 const redirectPath = ref('')
 
 // 處理登出
 const handleLogout = async () => {
   try {
-    await logout()
+    await userStore.logout()
     toast.success('登出成功')
     // 清除暱稱資料
     nicknameStorage.clearNickname()
@@ -31,9 +35,21 @@ const handleLogout = async () => {
   }
 }
 
+// 設置 Firebase Auth 監聽器，並將用戶信息同步到 store
+const setupAuthListener = () => {
+  return onAuthStateChanged(auth, (currentUser) => {
+    console.log('[Home] Auth state changed:', currentUser?.uid ? `User ${currentUser.uid}` : 'No user')
+    // 更新 userStore
+    userStore.setUser(currentUser)
+  })
+}
+
 // 檢查URL參數
 onMounted(() => {
   initialize()
+
+  // 設置 Firebase Auth 監聽器，將用戶信息同步到 store
+  const unsubscribe = setupAuthListener()
 
   // 檢查是否有提示設置暱稱的標記
   const requireNickname = route.query.requireNickname === 'true'
@@ -82,7 +98,7 @@ const version = computed(() => {
   <div class="flex flex-col min-h-screen w-full">
     <!-- 用戶下拉菜單 -->
     <div v-if="true" class="home-user-dropdown">
-      <UserDropdown :user="user" @logout="handleLogout" />
+      <UserDropdown :user="userStore.user" @logout="handleLogout" />
     </div>
 
     <!-- 主要內容 -->

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,12 +17,6 @@ const { user, logout, initialize } = useAuth()
 const shouldRedirect = ref(false)
 const redirectPath = ref('')
 
-// 計算屬性：是否應該提示用戶使用顯示名稱
-const shouldSuggestDisplayNameAsNickname = computed(() => {
-  if (!user.value || !user.value.displayName) return false;
-  return nicknameStorage.shouldUpdateFromDisplayName(user.value.displayName);
-})
-
 // 處理登出
 const handleLogout = async () => {
   try {

--- a/src/views/JoinRoom.vue
+++ b/src/views/JoinRoom.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useNicknameStorage } from '@/composables/storage/useNicknameStorage'
-import { useAuth } from '@/composables/auth/useAuth'
+import { useUserStore } from '@/stores'
 import { getRoomByCode, joinRoom } from '@/firebase/rooms'
 import NavigationBack from '@/components/common/NavigationBack.vue'
 import { useToast } from '@/composables/useToast'
@@ -13,7 +13,7 @@ const router = useRouter()
 const nicknameStorage = useNicknameStorage()
 const toast = useToast()
 const roomStore = useRoomStore()
-const auth = useAuth()
+const userStore = useUserStore()
 
 // 接收從路由傳遞的props
 const props = defineProps({
@@ -99,7 +99,7 @@ const handleJoinRoom = async () => {
     return
   }
 
-  if (!auth.user.value) {
+  if (!userStore.user) {
     toast.error('請先登入')
     router.push('/login')
     return
@@ -122,7 +122,7 @@ const handleJoinRoom = async () => {
 
     // 加入房間，使用用戶UID和暱稱
     const displayName = nicknameStorage.nickname.value
-    const result = await joinRoom(room.id, auth.user.value.uid, displayName)
+    const result = await joinRoom(room.id, userStore.user.uid, displayName)
 
     if (result.isExisting) {
       toast.info('使用已有的房間身份')

--- a/src/views/VotingForm.vue
+++ b/src/views/VotingForm.vue
@@ -174,7 +174,12 @@ onMounted(() => {
   }, 1000);
 });
 
+onMounted(async () => {
+  await getRoomData();
+});
+
 const roomName = computed(() => {
+
   return roomData?.value?.name || '無法取得房間名稱'
 });
 

--- a/src/views/VotingForm.vue
+++ b/src/views/VotingForm.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useToast } from '@/composables/useToast';
+import { useAuth } from '@/composables/auth/useAuth';
 import { submitVote, watchRoomVotes, getRoomById } from '@/firebase/rooms';
 import OptionGroup from '@/components/voting/OptionGroup.vue';
 import BudgetSlider from '@/components/voting/BudgetSlider.vue';
@@ -11,6 +12,7 @@ import CommentInput from '@/components/voting/CommentInput.vue';
 const route = useRoute();
 const router = useRouter();
 const toast = useToast();
+const auth = useAuth();
 
 // 表單資料
 const selectedFood = ref(null);
@@ -23,7 +25,6 @@ const isLoading = ref(false);
 const isSubmitted = ref(false);
 const error = ref(null);
 const roomId = ref('');
-const participantId = ref('');
 const unsubscribe = ref(null);
 const roomData = ref(null);
 const votingStatus = ref({
@@ -68,8 +69,8 @@ const handleSubmit = async () => {
     return;
   }
 
-  if (!roomId.value || !participantId.value) {
-    toast.error('房間資訊不完整，請返回等待頁面');
+  if (!roomId.value || !auth.user.value?.uid) {
+    toast.error('房間資訊不完整或未登入，請返回等待頁面');
     return;
   }
 
@@ -78,7 +79,7 @@ const handleSubmit = async () => {
 
   try {
     const voteData = getFormData();
-    await submitVote(roomId.value, participantId.value, voteData);
+    await submitVote(roomId.value, auth.user.value.uid, voteData);
 
     isSubmitted.value = true;
     toast.success('投票成功！等待其他人完成投票...');
@@ -105,7 +106,7 @@ const startWatchingVotes = () => {
     votingStatus.value = data;
 
     // 檢查是否當前用戶已投票
-    const currentUserVote = data.votes.find(v => v.participantId === participantId.value);
+    const currentUserVote = data.votes.find(v => v.userUid === auth.user.value?.uid);
     if (currentUserVote && currentUserVote.voteStatus === 'completed') {
       isSubmitted.value = true;
     }
@@ -124,28 +125,30 @@ const startWatchingVotes = () => {
 onMounted(() => {
   // 從URL獲取參數
   const urlRoomId = route.query.roomId;
-  const urlParticipantId = route.query.participantId;
 
-  if (!urlRoomId || !urlParticipantId) {
+  if (!urlRoomId) {
     // 嘗試從localStorage獲取
     const savedRoomId = localStorage.getItem('currentRoomId');
-    const savedParticipantId = localStorage.getItem('currentParticipantId');
 
-    if (!savedRoomId || !savedParticipantId) {
+    if (!savedRoomId) {
       toast.error('缺少必要參數，無法進行投票');
       router.push('/');
       return;
     }
 
     roomId.value = savedRoomId;
-    participantId.value = savedParticipantId;
   } else {
     roomId.value = urlRoomId;
-    participantId.value = urlParticipantId;
 
     // 保存到localStorage以便在頁面刷新時恢復
     localStorage.setItem('currentRoomId', urlRoomId);
-    localStorage.setItem('currentParticipantId', urlParticipantId);
+  }
+
+  // 檢查用戶是否已登入
+  if (!auth.user.value) {
+    toast.error('請先登入');
+    router.push('/login');
+    return;
   }
 
   // 開始監聽投票狀態

--- a/src/views/VotingResult.vue
+++ b/src/views/VotingResult.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useToast } from '@/composables/useToast';
+import { useUserStore } from '@/stores';
 import { getRoomVotes, getRecommendationResults, getRoomById } from '@/firebase/rooms';
 import axios from 'axios';
 import { useRecommendations } from '@/composables/useRecommendations';
@@ -9,6 +10,7 @@ import { useRecommendations } from '@/composables/useRecommendations';
 const route = useRoute();
 const router = useRouter();
 const toast = useToast();
+const userStore = useUserStore();
 const { getRecommendations } = useRecommendations();
 
 // 狀態
@@ -58,12 +60,17 @@ const formatVotesForApi = (roomData) => {
   return roomData.votes
     .filter(vote => vote.voteData) // 只包含有投票資料的參與者
     .map(vote => ({
+      // 將 userUid 映射為 API 所需的 participantId
       participantId: vote.userUid,
+      // 使用顯示名稱或預設為匿名用戶
       participantName: vote.displayName || '匿名用戶',
+      // 組合食物類型和口味，或取其中之一
       foodType: vote.voteData.flavor && vote.voteData.food
         ? `${vote.voteData.flavor}-${vote.voteData.food}`
         : (vote.voteData.flavor || vote.voteData.food || '未指定'),
+      // 預算，預設為500
       budget: vote.voteData.budget || 500,
+      // 備註
       comments: vote.voteData.comment || ''
     }));
 };
@@ -178,10 +185,9 @@ onMounted(async () => {
 
   await getRoomData();
 
-  // 獲取參與者ID
-  const savedParticipantId = localStorage.getItem('currentParticipantId');
-  if (savedParticipantId) {
-    participantId.value = savedParticipantId;
+  // 設置參與者ID
+  if (userStore.user) {
+    participantId.value = userStore.user.uid;
   }
 
   // 獲取投票資料
@@ -192,8 +198,8 @@ onMounted(async () => {
     votesData.value = roomData.votes || [];
 
     // 確定當前用戶是否為房主
-    if (participantId.value && roomData.votes) {
-      const currentUserData = roomData.votes.find(v => v.participantId === participantId.value);
+    if (userStore.user && roomData.votes) {
+      const currentUserData = roomData.votes.find(v => v.userUid === userStore.user.uid);
       isRoomOwner.value = currentUserData?.isOwner === true;
     }
 

--- a/src/views/VotingResult.vue
+++ b/src/views/VotingResult.vue
@@ -58,8 +58,8 @@ const formatVotesForApi = (roomData) => {
   return roomData.votes
     .filter(vote => vote.voteData) // 只包含有投票資料的參與者
     .map(vote => ({
-      participantId: vote.participantId,
-      participantName: vote.userId || '匿名用戶',
+      participantId: vote.userUid,
+      participantName: vote.displayName || '匿名用戶',
       foodType: vote.voteData.flavor && vote.voteData.food
         ? `${vote.voteData.flavor}-${vote.voteData.food}`
         : (vote.voteData.flavor || vote.voteData.food || '未指定'),


### PR DESCRIPTION
# [重構]: 將參與者識別從 UUID 切換為 Firebase UID

## 變更摘要
本次重構旨在統一應用程式中的用戶身份識別機制。原先系統允許匿名參與，使用 `crypto.randomUUID()` 生成臨時 `participantId`，並結合 `sessionId` 處理。此 PR 將其更改為**強制所有用戶登入 Firebase Authentication**，並使用 Firebase 返回的 `user.uid` 作為 Firestore 中 `participants` 集合的唯一標識符，移除了匿名參與功能。同時引入 Pinia `userStore` 來集中管理用戶狀態。

## 主要變更
- **Firebase Functions (`src/firebase/rooms.js`)**:
    - 重構 `createRoom`, `joinRoom`, `leaveRoom`, `submitVote`, `getRoomVotes`, `watchRoomVotes` 函數，將簽名和內部邏輯從接收/處理 `userId` (暱稱), `sessionId`, `participantId` (UUID) 更改為接收/處理 `userUid` (Firebase UID)。
    - 移除 `crypto.randomUUID()` 生成 `participantId` 的邏輯。
    - 移除 `sessionId` 相關的所有邏輯（包括重複加入的處理）。
    - 更新 Firestore 操作，使用 `userUid` 作為 `participants` map 的 key。
- **Pinia Store (`src/stores/user.js`)**:
    - 新增 `useUserStore`，用於集中存儲和管理當前登入用戶的 Firebase Auth 信息（uid, displayName, email, photoURL）和認證狀態。
    - 將登出邏輯移至 `userStore`。
- **狀態管理更新**:
    - 修改 `src/views/Home.vue`，在 `onAuthStateChanged` 回調中調用 `userStore.setUser`，將 Firebase Auth 狀態同步到 Pinia store。
    - 修改 `src/views/CreateRoom.vue`, `src/views/JoinRoom.vue`, `src/views/WaitingRoom.vue`, `src/views/VotingForm.vue`, `src/views/VotingResult.vue`，將原本直接調用 `useAuth()` 的地方改為使用 `useUserStore()` 來獲取用戶信息和狀態。
- **身份驗證強制執行**:
    - 確認相關路由 (`/create-room`, `/join-room`, `/waiting-room`, `/voting-form`, `/voting-result`) 在 `src/router/index.js` 中已設置 `meta: { requiresAuth: true }`。
    - 確認路由守衛 `router.beforeEach` 能正確攔截未登入用戶並重定向至登入頁面。
- **Composable (`src/composables/auth/useAuth.js`)**:
    - 將 `useAuth` 返回的 ref 狀態（user, loading, error）改為 `readonly`，避免意外修改。
    - （已移除）移除了短暫添加的 `isAuthReady` 狀態。

## UI 變更
無明顯視覺 UI 變更，主要是後端邏輯和狀態管理方式的調整。

## 測試覆蓋
- 需要手動測試以下流程：
    - 強制登入流程是否正常工作。
    - 已登入用戶創建、加入、投票、離開房間的功能。
    - 房主和參與者的權限區分是否正確。
    - 路由守衛是否能正確重定向未登入用戶。
    - 在不同頁面切換時，用戶狀態是否能通過 Pinia store 正確獲取。

## 相關問題
無

## 其他說明
- 此變更**移除了匿名參與功能**，所有用戶必須登入後才能使用房間相關功能。
- `useAuth` composable 現在主要負責初始化 Firebase 監聽器，而用戶狀態的讀取應通過 `useUserStore`。